### PR TITLE
Improve numeric keypad usability

### DIFF
--- a/style.css
+++ b/style.css
@@ -51,17 +51,22 @@ button{cursor:pointer}
 .hint{font-size:0.9rem;color:var(--muted);margin:0}
 .invalid{border-color:#d66;background:rgba(214,102,102,0.15)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-.keypad-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:flex-end;justify-content:center;z-index:9999}
+.keypad-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:flex-end;justify-content:center;z-index:9999;padding:0 12px 12px;padding:0 12px calc(12px + env(safe-area-inset-bottom))}
 .keypad-overlay.show{display:flex}
-.keypad{width:100%;max-width:460px;background:var(--panel);border:1px solid var(--border);border-radius:18px 18px 0 0;padding:16px 16px 10px;display:flex;flex-direction:column;gap:12px}
+.keypad{width:min(100%,440px);background:var(--panel);border:1px solid var(--border);border-radius:20px 20px 0 0;padding:18px 18px 14px;display:flex;flex-direction:column;gap:14px;box-shadow:0 -8px 28px rgba(0,0,0,0.35)}
 .keypad[aria-hidden="true"]{display:none}
-.keypad-display{font-size:24px;text-align:right;padding:12px;border:1px dashed var(--border);border-radius:12px;min-height:48px}
-.keypad-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}
-.keypad-grid button{min-height:56px;border-radius:14px;background:#3a3c43;border:1px solid var(--border);font-size:18px}
-.keypad-grid button[data-action="backspace"]{font-size:20px}
-.keypad-actions{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
-.keypad-actions button{min-height:50px;border-radius:12px;background:#3a3c43;border:1px solid var(--border);font-size:17px}
-.keypad-close{min-height:44px;border-radius:12px;border:1px solid var(--border);background:#3a3c43;font-size:16px}
+.keypad-display{font-size:clamp(1.45rem,4vw,1.8rem);text-align:right;padding:14px;border:1px dashed var(--border);border-radius:14px;min-height:54px;letter-spacing:1px}
+.keypad-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px}
+.keypad-grid button{min-height:64px;border-radius:16px;background:#3a3c43;border:1px solid var(--border);font-size:clamp(1.3rem,5vw,1.6rem);font-weight:600;touch-action:manipulation}
+.keypad-grid button[data-action="backspace"]{font-size:clamp(1.4rem,5.5vw,1.8rem)}
+.keypad-quick{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}
+.keypad-quick button{min-height:46px;border-radius:14px;background:#393b43;border:1px solid var(--border);font-size:1.05rem;font-weight:600;touch-action:manipulation}
+.keypad-quick button[data-delta^="-"]{background:#3a2f34}
+.keypad-quick button[data-delta^="+"]{background:#32423a}
+.keypad-actions{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+.keypad-actions button{min-height:56px;border-radius:14px;background:#3a3c43;border:1px solid var(--border);font-size:1.1rem;font-weight:700;touch-action:manipulation}
+.keypad-actions button[data-action="ok"]{background:var(--accent);color:#111}
+.keypad-close{min-height:48px;border-radius:14px;border:1px solid var(--border);background:#3a3c43;font-size:1rem;font-weight:600;touch-action:manipulation}
 @media (max-width:900px){
   .material-row{grid-template-columns:1.5fr 1fr 1fr;grid-auto-rows:auto}
   .material-row .item-total{grid-column:1/-1}


### PR DESCRIPTION
## Summary
- add quick increment buttons to the numeric keypad for faster adjustments
- clear default zero values when opening the keypad to avoid prefixed zeros
- tweak keypad layout and styling for a more touch-friendly mobile experience

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0a6f34184832aa16f9f38a7eada28