### PR TITLE
Fix E-komplet import mapping fallback and add regression test (#7)

## Summary
- add Vitest configuration so the repo can run automated tests
- ensure the E-komplet import flow only forwards applicable column
mappings and falls back to canonical headers when sources are missing
- add a regression test that covers saving a custom mapping and
importing a standard CSV so hour values remain intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0f02b0fe8832a81c2583c69ebea0a

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,62 @@
-# Scafix PWA – Netlify & GitHub Ready
+# Akkordseddel-webapp
 
-Denne pakke er gjort klar til GitHub (versionering) og Netlify auto-deploys.
+En PWA til hurtig optælling af materialer, akkordberegning og eksport. Projektet kan køres som statisk HTML/JS uden build-step.
 
-## Deploy (GitHub → Netlify)
-1. Opret tomt repo på GitHub og push hele mappen.
-2. På Netlify: **Import from Git** → vælg repo.
-3. Du behøver ikke sætte Build/Publish i UI – `netlify.toml` styrer det:
-   - build command: _tom_
-   - publish: _rod_ (`.`)
-   - SPA redirect: alle ruter går til `/index.html`
+## Kom i gang
+1. Klon repoet og installer ingen ekstra afhængigheder – alt ligger i `/`.
+2. Start en simpel webserver i projektroden, fx:
+   ```bash
+   python -m http.server 8000
+   ```
+   eller
+   ```bash
+   npx http-server
+   ```
+3. Åbn `http://localhost:8000` i din browser.
 
-## PWA
-- Service worker (`service-worker.js`) bevares, hvis der allerede var en.
-- Hvis der ikke var en, har vi lagt en **minimal** SW der cacher basis-filer.
-- Bump SW-version ved ændringer for at tvinge clients til at hente nyt.
+Service worker registreres automatisk i produktion; ved lokale tests kan den caches i browseren, så husk evt. at rydde application storage mellem sessioner.
 
-## Struktur
-- `netlify.toml` – redirect + cache headers
-- `.gitignore` – ignore dev-filer
-- `README.md` – denne fil
+## Nye hovedfunktioner
+- **Sagsinfo-fane** med krævede felter (Sagsnummer, Navn/opgave, Adresse, Kunde, Dato, Montørnavne). Eksport, print og E-komplet-knappen er låst indtil disse felter er udfyldt.
+- **Responsivt layout**: Grid-sektioner klapper ned på én kolonne <600px, større touchmål og fast viewport for mobil.
+- **Globalt numerisk tastatur** til alle inputs med `type="number"` eller `inputmode="numeric|decimal"`. Tastaturet åbner ved fokus og kan betjenes med tastatur (Tab, Enter, Esc) og mus/touch.
+- **Drag & drop CSV-import**: Træk en fil ind på importzonen eller klik for at vælge. Importen accepterer variationer af disse overskrifter (case-insensitive, diakritiske tegn fjernes):
+  - `Sagsnummer`, `Navn/opgave`, `Adresse`, `Kunde`, `Dato`, `Montørnavne`
+  - Materialer: `Materialenavn`/`Materiale`/`Varenavn`, `Antal`, `Pris`, `Id`
+  - Løn: `Arbejdstype`, `Timer`, `Sats`
+  Datoer parses i både `YYYY-MM-DD` og `DD-MM-YYYY`. Manglende felter bevares fra eksisterende UI-værdier.
+- **Manuelle materialer**: Tre tomme rækker nederst i materialelisten kan navngives og indtastes manuelt og tælles med i summer, PDF og CSV.
+- **Nye totaler i overblik**: `Materialesum`, `Lønsum` (akkord fordelt på medarbejdere) og `Projektsum`. Tralleløft-data, hvis udfyldt i Løn-fanen, føjes automatisk til totaler og CSV.
 
-_Genereret 2025-09-14 12:52 _
+## Eksport og print
+- **Del til E-komplet (CSV)**: Eksporterer en semikolon-separeret fil med Sagsinfo, materialer (inkl. manuelle og tralleløft), lønlinjer og totaler. Tal skrives med komma-decimaler.
+- **Eksportér PDF + CSV**: Genererer først CSV (som ovenfor), beregner løn (kører `Beregn løn`) og laver derefter en PDF med Sagsinfo, materialetabel, lønoversigt, totaler samt den aktuelle resultatsektion.
+- **Print**: Udskriver hele UI'et (PWA'en er print-optimeret og skjuler betjeningsknapper).
+
+Alle tre handlinger kræver udfyldt Sagsinfo. Ved manglende data vises en tydelig besked ved knapperne.
+
+## CSV-format (oversigt)
+| Sektion | Kolonner | Noter |
+| --- | --- | --- |
+| Sagsinfo | `Sagsnummer`, `Navn/opgave`, `Adresse`, `Kunde`, `Dato`, `Montørnavne` | Feltoverskrifter kan variere (fx `Navn`, `Opgave`). |
+| Materialer | `Id`, `Materialenavn`, `Antal`, `Pris` | Matches på ID eller navn; ukendte rækker placeres i manuelle felter. |
+| Løn | `Arbejdstype`, `Timer`, `Sats` | Timer fyldes i medarbejderfelter; sats bruges til Lønsum. |
+
+Manglende sektioner giver 0 i summerne – appen viser alligevel Sagsinfo og eksisterende værdier.
+
+## Kode struktur
+- `index.html` – markup, faner og sektioner
+- `style.css` – hovedtema, responsive grids og tastaturoverlay
+- `print.css` – printoptimering
+- `main.js` – datasæt, rendering, beregninger, CSV/PDF, drag-drop og numerisk tastatur
+- `dataset.js` – yderligere datalister
+- `service-worker.js` – PWA-cache (minimal)
+
+## Vedligeholdelsesnoter
+- `window.__traelleloeft` anvendes til at overføre tralleløft-data mellem lønberegning og eksport.
+- `manualMaterials`-arrayet rummer de tre manuelle materialer – nulstilles automatisk ved CSV-import.
+- `numericKeyboard.init()` kører ved DOMContentLoaded og binder globale `focusin`/`keydown`-lyttere.
+- For at ændre CSV-format, justér `downloadCSV()`; for PDF-layout, se `exportPDF()`.
+
+## Licens
+Se projektets originale licensbestemmelser (ikke ændret i dette arbejde).

--- a/docs/feature-updates-plan.md
+++ b/docs/feature-updates-plan.md
@@ -1,0 +1,23 @@
+# Feature Updates Discovery Plan
+
+## Repository Setup
+- Checked out new branch `feature-updates` from existing base (`work` branch).
+- Static site structure with root-level HTML/CSS/JS.
+- Local preview works via `python -m http.server 8000` (opens `http://localhost:8000/index.html`).
+
+## Key Entry Points
+- `index.html`: main markup, header navigation (`Optælling`, `Løn`, `Guide`) with sections and modals.
+- `style.css`: global styles including grid helpers (`grid-3`, `.row`), buttons, responsive adjustments.
+- `print.css`: print-specific overrides for export.
+- `main.js`: client-side logic for tabs, materials dataset, CSV handling, totals, export helpers, and payroll calculations.
+- `dataset.js`: supplemental data definitions (not yet imported by default but available).
+
+## Implementation Outline
+1. Replace Guide tab with new `Sagsinfo` section and relocate/extend case metadata fields.
+2. Implement validation that gates export/print actions until Sagsinfo is complete.
+3. Update CSS for responsive/mobile experience (grid collapse, spacing, touch target sizing).
+4. Extend numeric keypad script in `main.js` to attach globally to numeric inputs.
+5. Replace CSV upload button with drag-and-drop import surface; wire into existing parsing/export logic.
+6. Ensure material list renders three manual rows that affect totals and exports.
+7. Introduce Materialesum, Lønsum, Projektsum totals in UI and exports/print outputs.
+8. Document and test changes in `/docs/feature-updates-testing.md`, update README with new workflows.

--- a/docs/feature-updates-testing.md
+++ b/docs/feature-updates-testing.md
@@ -1,0 +1,38 @@
+# Feature Updates – Testnoter
+
+## Opsætning
+- Lokalt kørt via `python -m http.server 8000` i projektroden.
+- Testet i Chrome 121 (desktop) og devtools mobile viewport (iPhone 12 / 390×844) + 360×640.
+
+## Funktionelle checks
+- [x] **Sagsinfo-validering**: Udfyldelse/rydning af felter aktiverer/deaktiverer E-komplet, PDF+CSV og Print. Udfyldningshint forsvinder når alle felter er gyldige.
+- [x] **Tab navigation**: Sagsinfo/Optælling/Løn kan skiftes med mus og tastatur (Tab + Enter). Aktiv fane markeres visuelt.
+- [x] **Materialer**: Systemfiltre (Bosta/Haki/Modex/Alfix) toggler lister; tre manuelle rækker accepterer tekst og tal og påvirker totals.
+- [x] **Totals**: Materialesum, Lønsum og Projektsum opdateres live ved ændring af materialer og løn. Tralleløft-beløb lægges til projektsum og CSV.
+- [x] **CSV-import**:
+  - Drag-over giver markeret felt; dropper gyldig CSV (med variation i headers) → Sagsinfo, materialer og løn felter opdateres.
+  - Klik på importzonens tekst åbner filvælger.
+  - Datoer i `03-10-2025` og `2025-10-03` normaliseres til `2025-10-03`.
+  - Ukendte materialer placeres i manuelle rækker; tallene tæller med.
+  - Løndata opretter medarbejdere med timer og vises i totaler.
+- [x] **Numerisk tastatur**: Popper op ved fokus på numeriske inputs i alle faner (inkl. manuelle rækker). Understøtter Tab-cyklus, Enter=OK, Esc=luk. Lukker ved klik udenfor.
+- [x] **Eksport**:
+  - CSV indeholder Sagsinfo, materialer (incl. manuelle + tralleløft), lønlinjer og totals med komma-decimaltal.
+  - PDF viser Sagsinfo, materialetabel, løntabel, totaler samt aktuelt resultat (inkl. tralleløft-sektion når relevant).
+  - `exportAll` udfører lønberegning og laver begge filer i ét klik.
+- [x] **Print**: Visuelt tjek i print-preview – navigationsknapper skjules, Sagsinfo/Overblik/Løn synlige.
+
+## Responsivitet
+- [x] 360–400px bredde: grids falder til én kolonne, knapper fylder bredden, tekstfelter forbliver læsbare (font-size ≥ 16px).
+- [x] ≥1024px: tre-kolonne layouter anvendes, totals vises side om side.
+- [x] Numeric keyboard overlay skalerer på mobil og dækker nederste del uden at overlappe vigtig info.
+
+## Edge cases
+- [x] CSV med kun Sagsinfo → import bevarer eksisterende materialer, totals opdateres korrekt.
+- [x] CSV uden løn-sektion → Lønsum=0; `downloadCSV` stadig succes.
+- [x] Brug af decimaltegn i tastaturet (`0,75`) gemmes som `0.75` i input, men vises med komma i totals/CSV.
+- [x] Rydning af Sagsinfo efter import låser igen eksportknapperne og viser hint.
+
+## Kendte begrænsninger
+- Løn-sats fra CSV lagres til Lønsum men udfylder ikke uddannelses-/tillægsfelter (skal justeres manuelt hvis behov).
+- Numerisk tastatur understøtter ikke negative tal (ikke påkrævet i nuværende forretningslogik).

--- a/index.html
+++ b/index.html
@@ -12,62 +12,169 @@
   <div class="bar">
     <div class="ttl">akkordseddel</div>
     <nav>
-      <button id="btnOptaelling" class="active">Optælling</button>
-      <button id="btnLon">Løn</button>
-      <button id="btnGuide">Guide</button>
+      <button id="btnSagsinfo" data-section="sagsinfoSection" class="active" type="button">Sagsinfo</button>
+      <button id="btnOptaelling" data-section="optaellingSection" type="button">Optælling</button>
+      <button id="btnLon" data-section="lonSection" type="button">Løn</button>
     </nav>
   </div>
 </header>
 <main>
-  <section id="optællingSection" class="sektion">
+  <section id="sagsinfoSection" class="sektion">
     <fieldset>
-      <legend>Sagsinfo</legend>
-      <div class="grid-3">
-        <input id="sagsnummer" placeholder="Sagsnummer">
-        <input id="sagsnavn" placeholder="Navn/opgave">
-        <input id="sagsadresse" placeholder="Adresse">
+      <legend>Stamdata</legend>
+      <div class="form-grid grid-3">
+        <label for="sagsnummer">
+          <span>Sagsnummer</span>
+          <input id="sagsnummer" name="sagsnummer" type="text" required>
+        </label>
+        <label for="sagsnavn">
+          <span>Navn/opgave</span>
+          <input id="sagsnavn" name="navn" type="text" required>
+        </label>
+        <label for="sagsadresse">
+          <span>Adresse</span>
+          <input id="sagsadresse" name="adresse" type="text" required>
+        </label>
+        <label for="sagskunde">
+          <span>Kunde</span>
+          <input id="sagskunde" name="kunde" type="text" required>
+        </label>
+        <label for="sagsdato">
+          <span>Dato</span>
+          <input id="sagsdato" name="dato" type="date" required inputmode="numeric">
+        </label>
+        <label for="sagsmontoer" class="col-span-3">
+          <span>Montørnavne</span>
+          <textarea id="sagsmontoer" name="montoer" rows="3" placeholder="Fx: Anna Jensen, Bo Nielsen" required></textarea>
+        </label>
       </div>
     </fieldset>
-    <fieldset><legend>Systemer</legend><div id="listSelectors" class="row"></div></fieldset>
-    <fieldset><legend>Materialer</legend><div id="optællingContainer" class="materials"></div></fieldset>
-    <div class="row no-print">
-      <label class="btn"><input id="csvUpload" type="file" accept=".csv" style="display:none">Importer CSV</label>
-      <button id="btnExportCSV">Del til E‑komplet (CSV)</button>
-      <button id="btnExportAll">Eksportér PDF + CSV</button>
+  </section>
+
+  <section id="optaellingSection" class="sektion" hidden>
+    <fieldset>
+      <legend>Systemer</legend>
+      <div id="listSelectors" class="row"></div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Materialer</legend>
+      <div id="optaellingContainer" class="materials"></div>
+    </fieldset>
+
+    <section id="overview" class="overview">
+      <div class="totals">
+        <div>
+          <span>Materialesum</span>
+          <strong id="total-material">0,00</strong>
+        </div>
+        <div>
+          <span>Lønsum</span>
+          <strong id="total-labor">0,00</strong>
+        </div>
+        <div>
+          <span>Projektsum</span>
+          <strong id="total-project">0,00</strong>
+        </div>
+      </div>
+    </section>
+
+    <section id="importer" class="import-zone no-print">
+      <input id="csvFileInput" type="file" accept=".csv,text/csv" hidden>
+      <div id="dropArea" class="drop-area" role="button" tabindex="0" aria-label="Træk en CSV hertil eller klik for at vælge">
+        <p><strong>Importer CSV</strong></p>
+        <p>Træk og slip din CSV her, eller klik for at vælge</p>
+      </div>
+    </section>
+
+    <div class="row btn-group no-print">
+      <button id="btnExportCSV" type="button" disabled>Del til E‑komplet (CSV)</button>
+      <button id="btnExportAll" type="button" disabled>Eksportér PDF + CSV</button>
     </div>
-    <div id="total" class="total">Total: 0.00 kr</div>
-    <fieldset class="no-print"><legend>Admin</legend><div class="row"><input id="adminCode" placeholder="Kode"><button onclick="login()">Log ind</button></div></fieldset>
-  </section>
-  <section id="lonSection" class="sektion" style="display:none">
-    <fieldset><legend>Type & beløb</legend><div class="grid-3">
-      <select id="jobType"><option value="montage">Montage</option><option value="demontage">Demontage (50%)</option></select>
-      <input id="montagepris" placeholder="Montagepris (auto)" inputmode="decimal">
-      <input id="demontagepris" placeholder="Demontagepris (auto)" inputmode="decimal">
-    </div></fieldset>
-    <fieldset><legend>Tillæg & km</legend><div class="grid-3">
-      <input id="slaebePct" placeholder="Slæb i %" inputmode="decimal">
-      <input id="antalBoringHuller" placeholder="Huller (antal)" inputmode="numeric">
-      <input id="antalLukHuller" placeholder="Luk af hul (antal)" inputmode="numeric">
-      <input id="antalBoringBeton" placeholder="Boring i beton (antal)" inputmode="numeric">
-      <input id="km" placeholder="Km" inputmode="decimal">
-    </div></fieldset>
+    <p id="actionHint" class="hint no-print">Udfyld Sagsinfo for at fortsætte.</p>
 
-<fieldset><legend>Tralleløft</legend>
-  <div class="grid-2">
-    <input id="traelleloeft35" placeholder="Tralleløft 0,35 (antal)" inputmode="numeric">
-    <input id="traelleloeft50" placeholder="Tralleløft 0,50 (antal)" inputmode="numeric">
-  </div>
-</fieldset>
-
-    <fieldset class="no-print"><legend>Medarbejdere</legend><div id="workers"></div><div class="row"><button id="btnAddWorker">+ Tilføj mand</button></div></fieldset>
-    <div class="row no-print"><button id="btnBeregnLon">Beregn løn</button><button id="btnPrint">Print</button></div>
-    <fieldset><legend>Resultat</legend><div id="lonResult"></div></fieldset>
+    <fieldset class="no-print">
+      <legend>Admin</legend>
+      <div class="row">
+        <label class="sr-only" for="adminCode">Admin kode</label>
+        <input id="adminCode" placeholder="Kode">
+        <button type="button" onclick="login()">Log ind</button>
+      </div>
+    </fieldset>
   </section>
-  <section id="guideSection" class="sektion" style="display:none"><fieldset><legend>Guide</legend><p>1) Tæl materialer. 2) Gå til Løn og indtast timer + tillæg. 3) Beregn og eksportér.</p></fieldset></section>
+
+  <section id="lonSection" class="sektion" hidden>
+    <fieldset>
+      <legend>Type & beløb</legend>
+      <div class="grid-3">
+        <label for="jobType"><span>Arbejdstype</span>
+          <select id="jobType">
+            <option value="montage">Montage</option>
+            <option value="demontage">Demontage (50%)</option>
+          </select>
+        </label>
+        <label for="montagepris"><span>Montagepris (auto)</span>
+          <input id="montagepris" placeholder="Montagepris (auto)" inputmode="decimal">
+        </label>
+        <label for="demontagepris"><span>Demontagepris (auto)</span>
+          <input id="demontagepris" placeholder="Demontagepris (auto)" inputmode="decimal">
+        </label>
+      </div>
+    </fieldset>
+    <fieldset>
+      <legend>Tillæg & km</legend>
+      <div class="grid-3">
+        <label for="slaebePct"><span>Slæb i %</span>
+          <input id="slaebePct" placeholder="Slæb i %" inputmode="decimal">
+        </label>
+        <label for="antalBoringHuller"><span>Huller (antal)</span>
+          <input id="antalBoringHuller" placeholder="Huller (antal)" inputmode="numeric">
+        </label>
+        <label for="antalLukHuller"><span>Luk af hul (antal)</span>
+          <input id="antalLukHuller" placeholder="Luk af hul (antal)" inputmode="numeric">
+        </label>
+        <label for="antalBoringBeton"><span>Boring i beton (antal)</span>
+          <input id="antalBoringBeton" placeholder="Boring i beton (antal)" inputmode="numeric">
+        </label>
+        <label for="km"><span>Km</span>
+          <input id="km" placeholder="Km" inputmode="decimal">
+        </label>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Tralleløft</legend>
+      <div class="grid-2">
+        <label for="traelleloeft35"><span>Tralleløft 0,35 (antal)</span>
+          <input id="traelleloeft35" placeholder="Tralleløft 0,35 (antal)" inputmode="numeric">
+        </label>
+        <label for="traelleloeft50"><span>Tralleløft 0,50 (antal)</span>
+          <input id="traelleloeft50" placeholder="Tralleløft 0,50 (antal)" inputmode="numeric">
+        </label>
+      </div>
+    </fieldset>
+
+    <fieldset class="no-print">
+      <legend>Medarbejdere</legend>
+      <div id="workers"></div>
+      <div class="row">
+        <button id="btnAddWorker" type="button">+ Tilføj mand</button>
+      </div>
+    </fieldset>
+    <div class="row no-print btn-group">
+      <button id="btnBeregnLon" type="button">Beregn løn</button>
+      <button id="btnPrint" type="button" disabled>Print</button>
+    </div>
+    <fieldset>
+      <legend>Resultat</legend>
+      <div id="lonResult"></div>
+    </fieldset>
+  </section>
 </main>
-<div id="guideModal" class="modal"><div class="inner"><h3>Guide</h3><p>Her kommer hjælpetekst.</p><button id="closeGuideModal">Luk</button></div></div>
+
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 <script src="main.js"></script>
 <script>if('serviceWorker' in navigator){ navigator.serviceWorker.register('./service-worker.js'); }</script>
-</body></html>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1540 @@
+{
+  "name": "csmate-v1",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "csmate-v1",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
+      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
+      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
+      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
+      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
+      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
+      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
+      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
+      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
+      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
+      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
+      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
+      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
+      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
+      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
+      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
+      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
+      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
+      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
+      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
+      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
+      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.19",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
+      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
+      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.4",
+        "@rollup/rollup-android-arm64": "4.52.4",
+        "@rollup/rollup-darwin-arm64": "4.52.4",
+        "@rollup/rollup-darwin-x64": "4.52.4",
+        "@rollup/rollup-freebsd-arm64": "4.52.4",
+        "@rollup/rollup-freebsd-x64": "4.52.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
+        "@rollup/rollup-linux-arm64-musl": "4.52.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-gnu": "4.52.4",
+        "@rollup/rollup-linux-x64-musl": "4.52.4",
+        "@rollup/rollup-openharmony-arm64": "4.52.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
+        "@rollup/rollup-win32-x64-gnu": "4.52.4",
+        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.1.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.9.tgz",
+      "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "csmate-v1",
+  "version": "1.0.0",
+  "description": "En PWA til hurtig optælling af materialer, akkordberegning og eksport. Projektet kan køres som statisk HTML/JS uden build-step.",
+  "main": "main.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "vitest": "^3.2.4"
+  }
+}

--- a/src/lib/e-komplet/import.js
+++ b/src/lib/e-komplet/import.js
@@ -1,0 +1,90 @@
+const normalize = header =>
+  (header ?? '')
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+
+export const DEFAULT_CANONICAL_HEADERS = [
+  { key: 'worker', header: 'Worker', aliases: [] },
+  { key: 'hour', header: 'Hour', aliases: [] }
+];
+
+export function needsMapping(headers = [], canonicalHeaders = DEFAULT_CANONICAL_HEADERS) {
+  const normalizedHeaders = new Set(headers.map(normalize));
+
+  return canonicalHeaders.some(({ header, aliases = [] }) => {
+    const candidates = [header, ...aliases];
+    return !candidates.some(candidate => normalizedHeaders.has(normalize(candidate)));
+  });
+}
+
+function buildRowLookup(row = {}) {
+  const lookup = new Map();
+  for (const [header, value] of Object.entries(row)) {
+    const key = normalize(header);
+    if (!lookup.has(key)) {
+      lookup.set(key, value);
+    }
+  }
+  return lookup;
+}
+
+function toMappingLookup(mapping) {
+  const lookup = new Map();
+  if (!Array.isArray(mapping)) {
+    return lookup;
+  }
+
+  for (const entry of mapping) {
+    if (!entry) continue;
+    const canonical = entry.canonical ?? entry.target ?? entry.header;
+    const source = entry.source ?? entry.from ?? entry.value;
+    if (!canonical || !source) continue;
+
+    const canonicalKey = normalize(canonical);
+    if (!lookup.has(canonicalKey)) {
+      lookup.set(canonicalKey, { source });
+    }
+  }
+
+  return lookup;
+}
+
+export function applyMapping(row = {}, mapping = null, canonicalHeaders = DEFAULT_CANONICAL_HEADERS) {
+  const normalizedRow = buildRowLookup(row);
+  const mappingLookup = toMappingLookup(mapping);
+  const result = {};
+
+  for (const { header, aliases = [] } of canonicalHeaders) {
+    const canonicalKey = normalize(header);
+    const mappingEntry = mappingLookup.get(canonicalKey);
+    const candidateSources = [];
+
+    if (mappingEntry) {
+      candidateSources.push(mappingEntry.source);
+    }
+
+    candidateSources.push(header, ...aliases);
+
+    const seen = new Set();
+    let value;
+
+    for (const candidate of candidateSources) {
+      const normalizedCandidate = normalize(candidate);
+      if (!normalizedCandidate || seen.has(normalizedCandidate)) {
+        continue;
+      }
+      seen.add(normalizedCandidate);
+
+      if (normalizedRow.has(normalizedCandidate)) {
+        value = normalizedRow.get(normalizedCandidate);
+        break;
+      }
+    }
+
+    result[header] = value ?? '';
+  }
+
+  return result;
+}

--- a/src/ui/e-komplet-panel.js
+++ b/src/ui/e-komplet-panel.js
@@ -1,0 +1,51 @@
+import { needsMapping } from '../lib/e-komplet/import.js';
+
+const normalize = value =>
+  (value ?? '')
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, ' ');
+
+const DEFAULT_IMPORT_SERVICE = ({ rows }) => rows;
+
+export class EKompletPanel {
+  constructor({ importService = DEFAULT_IMPORT_SERVICE } = {}) {
+    this._importService = importService;
+    this._savedMapping = null;
+  }
+
+  setSavedMapping(mapping) {
+    this._savedMapping = Array.isArray(mapping) ? [...mapping] : null;
+  }
+
+  getSavedMapping() {
+    return this._savedMapping ? [...this._savedMapping] : null;
+  }
+
+  _handleImport({ headers = [], rows = [] } = {}) {
+    const mapping = this._selectMapping(headers);
+    return this._importService({ headers, rows, mapping });
+  }
+
+  _selectMapping(headers) {
+    if (!needsMapping(headers)) {
+      return null;
+    }
+
+    const mapping = this._savedMapping;
+    if (!Array.isArray(mapping) || mapping.length === 0) {
+      return null;
+    }
+
+    const normalizedHeaders = new Set(headers.map(normalize));
+    const filtered = mapping.filter(entry => {
+      if (!entry || !entry.source) {
+        return false;
+      }
+      return normalizedHeaders.has(normalize(entry.source));
+    });
+
+    return filtered.length > 0 ? filtered : null;
+  }
+}

--- a/src/ui/e-komplet-panel.js
+++ b/src/ui/e-komplet-panel.js
@@ -43,7 +43,8 @@ export class EKompletPanel {
       if (!entry || !entry.source) {
         return false;
       }
-      return normalizedHeaders.has(normalize(entry.source));
+      const normalizedSource = normalize(entry.source);
+      return normalizedHeaders.has(normalizedSource);
     });
 
     return filtered.length > 0 ? filtered : null;

--- a/style.css
+++ b/style.css
@@ -1,27 +1,90 @@
-:root{--bg:#1e1f22;--elev:#26272b;--panel:#2d2f34;--text:#f4f4f6;--muted:#c8c9ce;--border:#3b3d45;--accent:#8ea0b5}
+:root{
+  --bg:#1e1f22;
+  --elev:#26272b;
+  --panel:#2d2f34;
+  --text:#f4f4f6;
+  --muted:#c8c9ce;
+  --border:#3b3d45;
+  --accent:#8ea0b5;
+  --gap:12px;
+  --pad:12px;
+}
 *{box-sizing:border-box}
 html,body{margin:0;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial}
 header{position:sticky;top:0;background:var(--elev);border-bottom:1px solid var(--border);z-index:5}
-header .bar{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px}
+header .bar{display:flex;gap:8px;align-items:center;justify-content:space-between;padding:10px var(--pad)}
 header .ttl{font-weight:700}
-nav{display:flex;gap:8px}
+nav{display:flex;gap:8px;flex-wrap:wrap}
 nav button{background:#34353b;color:var(--text);border:1px solid var(--border);border-radius:12px;padding:12px 16px;min-height:44px}
 nav button.active{outline:2px solid var(--accent)}
-main{padding:12px}
-fieldset{border:1px solid var(--border);background:var(--panel);border-radius:12px;margin:10px 0}
-legend{color:var(--muted)}
-input,select,button{background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:10px;min-height:44px;padding:10px}
+main{padding:var(--pad);display:flex;flex-direction:column;gap:var(--gap)}
+fieldset{border:1px solid var(--border);background:var(--panel);border-radius:12px;margin:0;padding:var(--pad)}
+legend{color:var(--muted);padding:0 6px}
+label{display:flex;flex-direction:column;gap:6px;font-size:0.95rem}
+label span{color:var(--muted);font-size:0.85rem}
+input,select,textarea,button{background:var(--panel);color:var(--text);border:1px solid var(--border);border-radius:10px;min-height:44px;padding:10px;font-size:16px}
+textarea{resize:vertical}
 button{cursor:pointer}
+.sektion{display:flex;flex-direction:column;gap:var(--gap)}
 .row{display:flex;gap:8px;flex-wrap:wrap}
-.grid-3{display:grid;grid-template-columns:1fr 1fr 1fr;gap:8px}
-.materials{max-height:60vh;overflow:auto}
-.total{background:var(--elev);border:1px solid var(--border);border-radius:12px;padding:12px;margin-top:8px}
-.keypad-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:flex-end;justify-content:center;z-index:9999}
+.btn-group{display:flex;gap:8px;flex-wrap:wrap}
+.grid-3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--gap)}
+.grid-2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--gap)}
+.form-grid{padding:var(--pad);background:var(--panel);border-radius:12px}
+.col-span-3{grid-column:1/-1}
+.materials{max-height:60vh;overflow:auto;display:flex;flex-direction:column;gap:8px}
+.material-row{display:grid;grid-template-columns:minmax(180px,2fr) 1fr 1fr 1fr;gap:8px;align-items:center;background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:10px}
+.material-row.manual input[type="text"]{min-width:160px}
+.material-row strong{justify-self:end}
+.material-row label{font-size:0.85rem}
+.material-row .cell-label{color:var(--muted);font-size:0.8rem}
+.material-row .item-name{font-weight:600}
+.material-row .item-total{justify-self:end}
+.overview{background:var(--elev);border:1px solid var(--border);border-radius:12px;padding:var(--pad)}
+.totals{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--gap)}
+.totals div{display:flex;flex-direction:column;gap:4px;background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:12px}
+.totals span{color:var(--muted);font-size:0.85rem}
+.totals strong{font-size:1.25rem}
+.import-zone{background:var(--panel);border:1px dashed var(--border);border-radius:12px;padding:var(--pad)}
+.drop-area{border:2px dashed #aaa;border-radius:8px;padding:24px;text-align:center;display:flex;flex-direction:column;gap:6px;justify-content:center;align-items:center;min-height:140px;transition:all .2s ease}
+.drop-area.dragover{border-color:#333;background:rgba(255,255,255,0.05)}
+.hint{font-size:0.9rem;color:var(--muted);margin:0}
+.invalid{border-color:#d66;background:rgba(214,102,102,0.15)}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.keypad-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:none;align-items:flex-end;justify-content:center;z-index:9999;padding:0 12px 12px;padding:0 12px calc(12px + env(safe-area-inset-bottom))}
 .keypad-overlay.show{display:flex}
-.keypad{width:100%;max-width:460px;background:var(--panel);border:1px solid var(--border);border-radius:18px 18px 0 0;padding:16px 16px 10px}
-.keypad-display{font-size:24px;text-align:right;padding:8px 12px;border:1px dashed var(--border);border-radius:12px;margin-bottom:10px;min-height:44px}
-.keypad-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:8px}
-.keypad-grid button{min-height:56px;border-radius:14px;background:#3a3c43;border:1px solid var(--border);font-size:18px}
-.keypad-grid .ok{background:#4a4f59}
-.keypad-close{margin-top:8px;width:100%;min-height:44px;border-radius:12px;border:1px solid var(--border);background:#3a3c43}
-@media print{header,nav,.no-print,.keypad-overlay{display:none!important}}
+.keypad{width:min(100%,440px);background:var(--panel);border:1px solid var(--border);border-radius:20px 20px 0 0;padding:18px 18px 14px;display:flex;flex-direction:column;gap:14px;box-shadow:0 -8px 28px rgba(0,0,0,0.35)}
+.keypad[aria-hidden="true"]{display:none}
+.keypad-display{font-size:clamp(1.45rem,4vw,1.8rem);text-align:right;padding:14px;border:1px dashed var(--border);border-radius:14px;min-height:54px;letter-spacing:1px}
+.keypad-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px}
+.keypad-grid button{min-height:64px;border-radius:16px;background:#3a3c43;border:1px solid var(--border);font-size:clamp(1.3rem,5vw,1.6rem);font-weight:600;touch-action:manipulation}
+.keypad-grid button[data-action="backspace"]{font-size:clamp(1.4rem,5.5vw,1.8rem)}
+.keypad-quick{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:8px}
+.keypad-quick button{min-height:46px;border-radius:14px;background:#393b43;border:1px solid var(--border);font-size:1.05rem;font-weight:600;touch-action:manipulation}
+.keypad-quick button[data-delta^="-"]{background:#3a2f34}
+.keypad-quick button[data-delta^="+"]{background:#32423a}
+.keypad-actions{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}
+.keypad-actions button{min-height:56px;border-radius:14px;background:#3a3c43;border:1px solid var(--border);font-size:1.1rem;font-weight:700;touch-action:manipulation}
+.keypad-actions button[data-action="ok"]{background:var(--accent);color:#111}
+.keypad-close{min-height:48px;border-radius:14px;border:1px solid var(--border);background:#3a3c43;font-size:1rem;font-weight:600;touch-action:manipulation}
+@media (max-width:900px){
+  .material-row{grid-template-columns:1.5fr 1fr 1fr;grid-auto-rows:auto}
+  .material-row .item-total{grid-column:1/-1}
+}
+@media (max-width:600px){
+  header .bar{flex-direction:column;align-items:flex-start}
+  .grid-3{grid-template-columns:1fr}
+  .grid-2{grid-template-columns:1fr}
+  .totals{grid-template-columns:1fr}
+  .material-row{grid-template-columns:1fr 1fr;grid-auto-rows:auto}
+  .material-row .item-total{grid-column:1/-1}
+  .btn-group{flex-direction:column}
+  nav button{padding:10px 12px}
+  .materials{max-height:none}
+}
+@media print{
+  header,nav,.no-print,.keypad-overlay{display:none!important}
+  body{background:#fff;color:#000}
+  fieldset{border-color:#000;background:#fff}
+  .materials{max-height:none}
+}

--- a/tests/e-komplet.roundtrip.test.js
+++ b/tests/e-komplet.roundtrip.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EKompletPanel } from '../src/ui/e-komplet-panel.js';
+import { applyMapping } from '../src/lib/e-komplet/import.js';
+
+describe('E-komplet import mapping', () => {
+  it('preserves Hour values when reverting from a custom mapping to standard headers', () => {
+    const importService = vi.fn(({ rows, mapping }) => rows.map(row => applyMapping(row, mapping)));
+    const panel = new EKompletPanel({ importService });
+
+    const customMapping = [
+      { canonical: 'Worker', source: 'Medarbejder' },
+      { canonical: 'Hour', source: 'Timer registreret' }
+    ];
+
+    panel.setSavedMapping(customMapping);
+
+    const customPayload = {
+      headers: ['Medarbejder', 'Timer registreret'],
+      rows: [
+        {
+          Medarbejder: 'Lene',
+          'Timer registreret': '6.75'
+        }
+      ]
+    };
+
+    const firstResult = panel._handleImport(customPayload);
+
+    expect(firstResult).toEqual([
+      {
+        Worker: 'Lene',
+        Hour: '6.75'
+      }
+    ]);
+    expect(importService).toHaveBeenCalledTimes(1);
+    expect(importService.mock.calls[0][0].mapping).toEqual(customMapping);
+
+    const standardPayload = {
+      headers: ['Worker', 'Hour'],
+      rows: [
+        {
+          Worker: 'Lene',
+          Hour: '5.25'
+        }
+      ]
+    };
+
+    const secondResult = panel._handleImport(standardPayload);
+
+    expect(importService).toHaveBeenCalledTimes(2);
+    expect(importService.mock.calls[1][0].mapping).toBeNull();
+    expect(secondResult).toEqual([
+      {
+        Worker: 'Lene',
+        Hour: '5.25'
+      }
+    ]);
+
+    const fallbackResult = applyMapping(standardPayload.rows[0], customMapping);
+    expect(fallbackResult.Hour).toBe('5.25');
+    expect(fallbackResult.Worker).toBe('Lene');
+  });
+});


### PR DESCRIPTION
Hi