### PR TITLE
Ensure canonical E-Komplet headers override saved mappings

### DIFF
--- a/src/lib/e-komplet/import.js
+++ b/src/lib/e-komplet/import.js
@@ -109,6 +109,10 @@ export function applyMapping (rows, mapping) {
   return rows.map(row => {
     const mapped = {}
     CSV_HEADERS.forEach(header => {
+      if (Object.prototype.hasOwnProperty.call(row, header)) {
+        mapped[header] = row[header] ?? ''
+        return
+      }
       const source = mapping?.[header] || header
       mapped[header] = row[source] ?? ''
     })

--- a/src/lib/e-komplet/import.js
+++ b/src/lib/e-komplet/import.js
@@ -109,7 +109,7 @@ export function applyMapping (rows, mapping) {
   return rows.map(row => {
     const mapped = {}
     CSV_HEADERS.forEach(header => {
-      if (Object.prototype.hasOwnProperty.call(row, header)) {
+      if (Object.hasOwn(row, header)) {
         mapped[header] = row[header] ?? ''
         return
       }

--- a/src/ui/e-komplet-panel.js
+++ b/src/ui/e-komplet-panel.js
@@ -176,14 +176,24 @@ export class EKompletPanel {
       this.statusEl.textContent = 'Kunne ikke læse filen.'
       return
     }
-    let mapping = this.state.mapping
+    const savedMapping = this.state.mapping || {}
+    const inferred = inferMapping(headers)
+    const cleanedMapping = { ...savedMapping }
+    CSV_HEADERS.forEach(header => {
+      if (headers.includes(header)) {
+        delete cleanedMapping[header]
+      }
+    })
+    const mapping = { ...cleanedMapping, ...inferred }
     if (needsMapping(headers)) {
-      mapping = { ...mapping, ...inferMapping(headers) }
+      this.state.mapping = mapping
       this.pendingImport = { headers, rows }
       this._renderMapping(headers, mapping)
       this.statusEl.textContent = 'Vælg kolonner for at fortsætte.'
       return
     }
+    this.state.mapping = mapping
+    persistMapping(mapping)
     this._applyImportedRows(headers, rows, mapping)
   }
 

--- a/tests/e-komplet.import.test.js
+++ b/tests/e-komplet.import.test.js
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { parseCsv, applyMapping } from '../src/lib/e-komplet/import.js'
+
+describe('E-Komplet import mapping', () => {
+  it('prefers canonical headers over saved overrides', async () => {
+    const csv = 'Hours,Timer\n7.5,8.0\n'
+    const { rows } = await parseCsv(csv)
+    const savedMapping = { Hours: 'Timer' }
+
+    const mapped = applyMapping(rows, savedMapping)
+
+    expect(mapped).toHaveLength(1)
+    expect(mapped[0].Hours).toBe('7.5')
+  })
+})


### PR DESCRIPTION
## Summary
- clear conflicting saved mapping entries when canonical headers are detected during import
- prefer direct CSV headers when mapping rows to the canonical schema
- add a vitest to cover importing Hours when a saved mapping points to Timer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e34abbad34832a880b32b366190357