### PR TITLE
Add Alfix system support and improve mobile materials UI

### DIFF
--- a/style.css
+++ b/style.css
@@ -32,13 +32,17 @@ button{cursor:pointer}
 .grid-2{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:var(--gap)}
 .form-grid{padding:var(--pad);background:var(--panel);border-radius:12px}
 .col-span-3{grid-column:1/-1}
-.materials{max-height:60vh;overflow:auto;display:flex;flex-direction:column;gap:8px}
+.materials{max-height:60vh;overflow:auto;display:flex;flex-direction:column;gap:8px;width:100%}
 .material-row{display:grid;grid-template-columns:minmax(200px,2fr) repeat(2,minmax(0,1fr)) minmax(120px,1fr);gap:10px;align-items:center;background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:12px}
 .material-row.manual input[type="text"]{min-width:160px}
 .material-row strong{justify-self:end}
 .material-row label{font-size:0.85rem}
 .material-row .cell-label{color:var(--muted);font-size:0.8rem}
 .material-row .item-name{font-weight:600}
+.material-row .item-name-wrapper{display:flex;flex-direction:column;gap:6px}
+.material-row .item-id{color:var(--muted);font-size:0.75rem;letter-spacing:0.01em}
+.manual-name-cell{display:flex;flex-direction:column;gap:6px}
+.manual-name-cell .item-id{font-size:0.75rem;color:var(--muted)}
 .material-row .item-total{justify-self:end}
 .material-row .system-badge{display:inline-flex;align-items:center;justify-content:center;margin-left:8px;padding:2px 8px;border-radius:999px;border:1px solid var(--border);background:rgba(142,160,181,0.15);color:var(--accent);font-size:0.7rem;letter-spacing:0.02em;text-transform:uppercase}
 .empty-state{margin:0;padding:16px;border:1px dashed var(--border);border-radius:12px;text-align:center;color:var(--muted);background:rgba(255,255,255,0.03)}
@@ -111,7 +115,7 @@ button{cursor:pointer}
   .material-row .item-total{grid-column:1/-1}
   .btn-group{flex-direction:column}
   nav button{padding:10px 12px}
-  .materials{max-height:none}
+  .materials{max-height:65vh;overflow:auto;padding-right:4px}
   .system-selector-options{gap:8px}
   .system-option{flex:1 1 calc(50% - 8px);justify-content:flex-start}
 }


### PR DESCRIPTION
## Summary
- add the Alfix material dataset and wire it into the multi-system selector
- merge duplicate material lines, display item IDs, and refresh the optælling UI for multi-select workflows
- tune mobile input behaviour to dismiss keyboards on enter/change and update responsive styling for small screens

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e405f3ddac832a99068853825b699c