### PR TITLE
Refine tab switching and service worker caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
       <button id="btnSagsinfo" data-section="sagsinfo" class="active" type="button">Sagsinfo</button>
       <button id="btnOptaelling" data-section="optaelling" type="button">Optælling</button>
       <button id="btnLon" data-section="lon" type="button">Løn</button>
-      <button id="btnGuide" data-section="guide" type="button">Guide</button>
     </nav>
   </div>
 </header>
@@ -23,6 +22,21 @@
   <section id="sagsinfoSection" class="sektion">
     <fieldset>
       <legend>Stamdata</legend>
+      <div class="status-bar">
+        <label for="sagStatus" class="status-select">
+          <span>Status</span>
+          <select id="sagStatus" name="sagStatus">
+            <option value="kladde">Kladde</option>
+            <option value="afventer">Afventer</option>
+            <option value="godkendt">Godkendt</option>
+            <option value="afvist">Afvist</option>
+          </select>
+        </label>
+        <div class="status-indicator">
+          <span>Aktuel status</span>
+          <strong id="statusIndicator" data-status="kladde" class="status-pill">Kladde</strong>
+        </div>
+      </div>
       <div class="form-grid grid-3">
         <label for="sagsnummer">
           <span>Sagsnummer</span>
@@ -52,6 +66,9 @@
           <textarea id="sagsmontoer" name="montoer" rows="3" placeholder="Fx: Anna Jensen, Bo Nielsen" required></textarea>
         </label>
       </div>
+      <div class="form-actions no-print">
+        <button id="btnOpenGuideModal" type="button">Åbn guide</button>
+      </div>
     </fieldset>
   </section>
 
@@ -70,30 +87,36 @@
       <div class="totals">
         <div>
           <span>Materialesum</span>
-          <strong id="total-material">0,00</strong>
+          <strong data-total="material">0,00</strong>
         </div>
         <div>
           <span>Lønsum</span>
-          <strong id="total-labor">0,00</strong>
+          <strong data-total="labor">0,00</strong>
         </div>
         <div>
           <span>Projektsum</span>
-          <strong id="total-project">0,00</strong>
+          <strong data-total="project">0,00</strong>
         </div>
       </div>
     </section>
 
     <section id="importer" class="import-zone no-print">
-      <input id="csvFileInput" type="file" accept=".csv,text/csv" hidden>
-      <div id="dropArea" class="drop-area" role="button" tabindex="0" aria-label="Træk en CSV hertil eller klik for at vælge">
-        <p><strong>Importer CSV</strong></p>
-        <p>Træk og slip din CSV her, eller klik for at vælge</p>
+      <input id="csvFileInput" type="file" accept=".csv,text/csv,.json,application/json" hidden>
+      <div id="dropArea" class="drop-area" role="button" tabindex="0" aria-label="Træk en CSV eller JSON hertil eller klik for at vælge">
+        <p><strong>Importer fil</strong></p>
+        <p>Træk og slip din CSV/JSON her, eller klik for at vælge</p>
+      </div>
+      <div class="recent-cases">
+        <label for="recentCases" class="sr-only">Seneste sager</label>
+        <select id="recentCases" aria-label="Seneste sager"></select>
+        <button type="button" id="btnLoadCase" disabled>Indlæs sag</button>
       </div>
     </section>
 
     <div class="row btn-group no-print">
       <button id="btnExportCSV" type="button" disabled>Del til E‑komplet (CSV)</button>
       <button id="btnExportAll" type="button" disabled>Eksportér PDF + CSV</button>
+      <button id="btnExportZip" type="button" disabled>Del til E‑komplet (ZIP)</button>
     </div>
     <p id="actionHint" class="hint no-print">Udfyld Sagsinfo for at fortsætte.</p>
 
@@ -128,10 +151,19 @@
     </fieldset>
     <fieldset>
       <legend>Tillæg & km</legend>
-      <div class="grid-3">
+      <div class="grid-2">
         <label for="slaebePct"><span>Slæb i %</span>
           <input id="slaebePct" placeholder="Slæb i %" inputmode="decimal">
         </label>
+        <label for="km"><span>Km</span>
+          <input id="km" placeholder="Km" inputmode="decimal">
+        </label>
+      </div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Ekstra arbejde</legend>
+      <div class="grid-3 extra-work-grid">
         <label for="antalBoringHuller"><span>Huller (antal)</span>
           <input id="antalBoringHuller" placeholder="Huller (antal)" inputmode="numeric">
         </label>
@@ -141,15 +173,6 @@
         <label for="antalBoringBeton"><span>Boring i beton (antal)</span>
           <input id="antalBoringBeton" placeholder="Boring i beton (antal)" inputmode="numeric">
         </label>
-        <label for="km"><span>Km</span>
-          <input id="km" placeholder="Km" inputmode="decimal">
-        </label>
-      </div>
-    </fieldset>
-
-    <fieldset>
-      <legend>Tralleløft</legend>
-      <div class="grid-2">
         <label for="traelleloeft35"><span>Tralleløft 0,35 (antal)</span>
           <input id="traelleloeft35" placeholder="Tralleløft 0,35 (antal)" inputmode="numeric">
         </label>
@@ -159,13 +182,23 @@
       </div>
     </fieldset>
 
-    <fieldset class="no-print">
-      <legend>Medarbejdere</legend>
-      <div id="workers"></div>
-      <div class="row">
-        <button id="btnAddWorker" type="button">+ Tilføj mand</button>
+    <section class="overview overview-inline">
+      <div class="totals">
+        <div>
+          <span>Materialesum</span>
+          <strong data-total="material">0,00</strong>
+        </div>
+        <div>
+          <span>Lønsum</span>
+          <strong data-total="labor">0,00</strong>
+        </div>
+        <div>
+          <span>Projektsum</span>
+          <strong data-total="project">0,00</strong>
+        </div>
       </div>
-    </fieldset>
+    </section>
+
     <div class="row no-print btn-group">
       <button id="btnBeregnLon" type="button">Beregn løn</button>
       <button id="btnPrint" type="button" disabled>Print</button>
@@ -174,17 +207,14 @@
       <legend>Resultat</legend>
       <div id="lonResult"></div>
     </fieldset>
-  </section>
 
-  <section id="guideSection" class="sektion" hidden>
-    <article class="guide-intro">
-      <h2>Sådan bruger du CSMate</h2>
-      <p>
-        Brug fanerne øverst til at udfylde sagsinfo, registrere materialer og beregne løn. Klik på
-        knappen herunder for at åbne den detaljerede trin-for-trin guide.
-      </p>
-      <button id="btnOpenGuideModal" type="button">Åbn guide</button>
-    </article>
+    <fieldset class="no-print">
+      <legend>Medarbejdere</legend>
+      <div id="workers"></div>
+      <div class="row">
+        <button id="btnAddWorker" type="button">+ Tilføj mand</button>
+      </div>
+    </fieldset>
   </section>
 </main>
 
@@ -208,6 +238,7 @@
   </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 <script src="main.js"></script>

--- a/index.html
+++ b/index.html
@@ -211,6 +211,20 @@
 <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 <script src="main.js"></script>
-<script>if('serviceWorker' in navigator){ navigator.serviceWorker.register('./service-worker.js'); }</script>
+<script>
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('./service-worker.js').then(reg => {
+      reg.onupdatefound = () => {
+        const newWorker = reg.installing;
+        if (!newWorker) return;
+        newWorker.onstatechange = () => {
+          if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+            window.location.reload();
+          }
+        };
+      };
+    });
+  }
+</script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -106,7 +106,6 @@ function setupGuideModal() {
   });
 
   document.getElementById('btnOpenGuideModal')?.addEventListener('click', () => {
-    vis('guide');
     openGuideModal();
   });
 
@@ -148,7 +147,14 @@ let laborEntries = [];
 let lastLoensum = 0;
 let lastMaterialSum = 0;
 let lastEkompletData = null;
+let currentStatus = 'kladde';
+let recentCasesCache = [];
+let cachedDBPromise = null;
 const DEFAULT_ACTION_HINT = 'Udfyld Sagsinfo for at fortsætte.';
+const DB_NAME = 'csmate_projects';
+const DB_STORE = 'projects';
+const TRAELLE_RATE35 = 10.44;
+const TRAELLE_RATE50 = 14.62;
 
 // --- Scaffold Part Lists ---
 const dataBosta = [
@@ -925,23 +931,49 @@ function calcLoensum() {
 }
 
 function renderCurrency(target, value) {
-  const el = typeof target === 'string' ? document.querySelector(target) : target;
-  if (!el) return;
-  el.textContent = `${formatCurrency(value)} kr`;
+  let elements = [];
+  if (typeof target === 'string') {
+    elements = Array.from(document.querySelectorAll(target));
+  } else if (target instanceof Element) {
+    elements = [target];
+  } else if (target && typeof target.length === 'number') {
+    elements = Array.from(target);
+  }
+  if (elements.length === 0) return;
+  const text = `${formatCurrency(value)} kr`;
+  elements.forEach(el => {
+    el.textContent = text;
+  });
 }
 
 let totalsUpdateTimer = null;
 
+function updateTralleStateFromInputs() {
+  if (typeof window === 'undefined') return;
+  const n35 = toNumber(document.getElementById('traelleloeft35')?.value);
+  const n50 = toNumber(document.getElementById('traelleloeft50')?.value);
+  window.__traelleloeft = {
+    n35,
+    n50,
+    RATE35: TRAELLE_RATE35,
+    RATE50: TRAELLE_RATE50,
+    sum: (n35 * TRAELLE_RATE35) + (n50 * TRAELLE_RATE50),
+  };
+}
+
 function performTotalsUpdate() {
-  const materialSum = calcMaterialesum();
+  updateTralleStateFromInputs();
+  const tralleState = typeof window !== 'undefined' ? window.__traelleloeft : null;
+  const tralleSum = tralleState && Number.isFinite(tralleState.sum) ? tralleState.sum : 0;
+  const materialSum = calcMaterialesum() + tralleSum;
   lastMaterialSum = materialSum;
-  renderCurrency('#total-material', materialSum);
+  renderCurrency('[data-total="material"]', materialSum);
 
   const laborSum = calcLoensum();
   lastLoensum = laborSum;
-  renderCurrency('#total-labor', laborSum);
+  renderCurrency('[data-total="labor"]', laborSum);
 
-  renderCurrency('#total-project', materialSum + laborSum);
+  renderCurrency('[data-total="project"]', materialSum + laborSum);
 
   const montageField = document.getElementById('montagepris');
   if (montageField) {
@@ -987,6 +1019,7 @@ function collectSagsinfo() {
     kunde: document.getElementById('sagskunde')?.value.trim() || '',
     dato: document.getElementById('sagsdato')?.value || '',
     montoer: document.getElementById('sagsmontoer')?.value.trim() || '',
+    status: currentStatus,
   };
 }
 
@@ -1014,6 +1047,371 @@ function updateActionHint(message = '', variant = 'info') {
   hint.style.display = '';
 }
 
+function formatStatusLabel(status) {
+  const normalized = (status || '').toLowerCase();
+  const labels = {
+    kladde: 'Kladde',
+    afventer: 'Afventer',
+    godkendt: 'Godkendt',
+    afvist: 'Afvist',
+  };
+  if (labels[normalized]) return labels[normalized];
+  if (!normalized) return 'Kladde';
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function syncStatusUI(status) {
+  const indicator = document.getElementById('statusIndicator');
+  if (indicator) {
+    indicator.textContent = formatStatusLabel(status);
+    indicator.dataset.status = status || 'kladde';
+  }
+  const select = document.getElementById('sagStatus');
+  if (select && (status ?? '') !== select.value) {
+    select.value = status || 'kladde';
+  }
+}
+
+function updateStatus(value, options = {}) {
+  const next = (value || '').toLowerCase() || 'kladde';
+  if (!admin && (next === 'godkendt' || next === 'afvist')) {
+    if (options?.source === 'control') {
+      syncStatusUI(currentStatus);
+    }
+    updateActionHint('Kun kontor kan godkende/afvise.', 'error');
+    return;
+  }
+  currentStatus = next;
+  syncStatusUI(currentStatus);
+}
+
+function initStatusControls() {
+  syncStatusUI(currentStatus);
+  const select = document.getElementById('sagStatus');
+  if (select) {
+    select.addEventListener('change', event => {
+      updateStatus(event.target.value, { source: 'control' });
+    });
+  }
+}
+
+function promisifyRequest(request) {
+  if (!request) return Promise.resolve(undefined);
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function openDB() {
+  if (cachedDBPromise) return cachedDBPromise;
+  if (typeof indexedDB === 'undefined') {
+    cachedDBPromise = Promise.reject(new Error('IndexedDB er ikke tilgængelig'));
+    cachedDBPromise.catch(() => {});
+    return cachedDBPromise;
+  }
+  cachedDBPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = event => {
+      const db = event.target?.result;
+      if (db && !db.objectStoreNames.contains(DB_STORE)) {
+        db.createObjectStore(DB_STORE, { keyPath: 'id', autoIncrement: true });
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error || new Error('IndexedDB kunne ikke åbnes'));
+  });
+  cachedDBPromise.catch(() => {
+    cachedDBPromise = null;
+  });
+  return cachedDBPromise;
+}
+
+async function saveProject(data) {
+  if (!data) return;
+  try {
+    const db = await openDB();
+    if (!db) return;
+    const tx = db.transaction(DB_STORE, 'readwrite');
+    const completion = new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onabort = () => reject(tx.error || new Error('Transaktionen blev afbrudt'));
+      tx.onerror = () => reject(tx.error || new Error('Transaktionen fejlede'));
+    });
+    const store = tx.objectStore(DB_STORE);
+    await promisifyRequest(store.add({ data, ts: Date.now() }));
+    const all = await promisifyRequest(store.getAll());
+    if (Array.isArray(all) && all.length > 20) {
+      all.sort((a, b) => (a.ts || 0) - (b.ts || 0));
+      const excess = all.length - 20;
+      for (let index = 0; index < excess; index += 1) {
+        const item = all[index];
+        if (item && item.id != null) {
+          await promisifyRequest(store.delete(item.id));
+        }
+      }
+    }
+    await completion;
+  } catch (error) {
+    console.warn('Kunne ikke gemme sag lokalt', error);
+  }
+}
+
+async function getRecentProjects() {
+  try {
+    const db = await openDB();
+    if (!db) return [];
+    const tx = db.transaction(DB_STORE, 'readonly');
+    const completion = new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onabort = () => reject(tx.error || new Error('Transaktionen blev afbrudt'));
+      tx.onerror = () => reject(tx.error || new Error('Transaktionen fejlede'));
+    });
+    const store = tx.objectStore(DB_STORE);
+    const items = await promisifyRequest(store.getAll());
+    await completion;
+    if (!Array.isArray(items)) return [];
+    return items
+      .filter(entry => entry && entry.data)
+      .sort((a, b) => (b.ts || 0) - (a.ts || 0));
+  } catch (error) {
+    console.warn('Kunne ikke hente lokale sager', error);
+    return [];
+  }
+}
+
+async function populateRecentCases() {
+  const select = document.getElementById('recentCases');
+  if (!select) return;
+  const button = document.getElementById('btnLoadCase');
+  const cases = await getRecentProjects();
+  recentCasesCache = cases;
+  select.innerHTML = '';
+
+  if (!cases.length) {
+    const option = document.createElement('option');
+    option.value = '';
+    option.textContent = 'Ingen gemte sager endnu';
+    option.disabled = true;
+    option.selected = true;
+    select.appendChild(option);
+    if (button) button.disabled = true;
+    return;
+  }
+
+  const placeholder = document.createElement('option');
+  placeholder.value = '';
+  placeholder.textContent = 'Vælg gemt sag';
+  placeholder.disabled = true;
+  placeholder.selected = true;
+  select.appendChild(placeholder);
+
+  cases.forEach(entry => {
+    const option = document.createElement('option');
+    option.value = String(entry.id);
+    const info = entry.data?.sagsinfo || {};
+    const parts = [];
+    if (info.sagsnummer) parts.push(info.sagsnummer);
+    if (info.navn) parts.push(info.navn);
+    option.textContent = parts.length ? parts.join(' – ') : `Sag #${entry.id}`;
+    select.appendChild(option);
+  });
+
+  if (button) button.disabled = true;
+}
+
+function collectExtrasState() {
+  const getValue = id => document.getElementById(id)?.value ?? '';
+  return {
+    jobType: document.getElementById('jobType')?.value || 'montage',
+    montagepris: getValue('montagepris'),
+    demontagepris: getValue('demontagepris'),
+    slaebePct: getValue('slaebePct'),
+    antalBoringHuller: getValue('antalBoringHuller'),
+    antalLukHuller: getValue('antalLukHuller'),
+    antalBoringBeton: getValue('antalBoringBeton'),
+    km: getValue('km'),
+    traelle35: getValue('traelleloeft35'),
+    traelle50: getValue('traelleloeft50'),
+  };
+}
+
+function collectProjectSnapshot() {
+  const materials = getAllData().map(item => ({
+    id: item.id,
+    name: item.name,
+    price: toNumber(item.price),
+    quantity: toNumber(item.quantity),
+    manual: Boolean(item.manual),
+    varenr: item.varenr || null,
+  }));
+  const labor = Array.isArray(laborEntries)
+    ? laborEntries.map(entry => ({ ...entry }))
+    : [];
+  return {
+    timestamp: Date.now(),
+    status: currentStatus,
+    sagsinfo: collectSagsinfo(),
+    systems: Array.from(selectedSystemKeys),
+    materials,
+    labor,
+    extras: collectExtrasState(),
+    totals: {
+      materialSum: lastMaterialSum,
+      laborSum: lastLoensum,
+    },
+  };
+}
+
+async function persistProjectSnapshot() {
+  try {
+    const snapshot = collectProjectSnapshot();
+    await saveProject(snapshot);
+    await populateRecentCases();
+  } catch (error) {
+    console.warn('Kunne ikke gemme projekt snapshot', error);
+  }
+}
+
+function applyExtrasSnapshot(extras = {}) {
+  const assign = (id, value) => {
+    const el = document.getElementById(id);
+    if (el) el.value = value ?? '';
+  };
+  const jobType = document.getElementById('jobType');
+  if (jobType && extras.jobType) {
+    jobType.value = extras.jobType;
+  }
+  assign('montagepris', extras.montagepris);
+  assign('demontagepris', extras.demontagepris);
+  assign('slaebePct', extras.slaebePct);
+  assign('antalBoringHuller', extras.antalBoringHuller);
+  assign('antalLukHuller', extras.antalLukHuller);
+  assign('antalBoringBeton', extras.antalBoringBeton);
+  assign('km', extras.km);
+  assign('traelleloeft35', extras.traelle35);
+  assign('traelleloeft50', extras.traelle50);
+
+  if (typeof window !== 'undefined') {
+    const n35 = toNumber(extras.traelle35);
+    const n50 = toNumber(extras.traelle50);
+    const sum = (n35 * TRAELLE_RATE35) + (n50 * TRAELLE_RATE50);
+    window.__traelleloeft = {
+      n35,
+      n50,
+      RATE35: TRAELLE_RATE35,
+      RATE50: TRAELLE_RATE50,
+      sum,
+    };
+  }
+}
+
+function applyMaterialsSnapshot(materials = [], systems = []) {
+  resetMaterials();
+  if (Array.isArray(systems) && systems.length) {
+    selectedSystemKeys.clear();
+    systems.forEach(key => selectedSystemKeys.add(key));
+  }
+  if (Array.isArray(materials)) {
+    materials.forEach(item => {
+      const quantity = toNumber(item?.quantity);
+      const price = toNumber(item?.price);
+      let target = null;
+      if (item?.id) {
+        target = findMaterialById(item.id);
+      }
+      if (target && !target.manual) {
+        target.quantity = quantity;
+        if (Number.isFinite(price) && price > 0) {
+          target.price = price;
+        }
+        return;
+      }
+      if (item?.manual) {
+        const slot = manualMaterials.find(man => man.id === item.id)
+          || manualMaterials.find(man => !man.name && man.quantity === 0 && man.price === 0);
+        if (slot) {
+          slot.name = item.name || slot.name;
+          slot.price = Number.isFinite(price) ? price : slot.price;
+          slot.quantity = quantity;
+        }
+        return;
+      }
+      const fallback = manualMaterials.find(man => !man.name && man.quantity === 0 && man.price === 0);
+      if (fallback) {
+        fallback.name = item?.name || '';
+        fallback.price = Number.isFinite(price) ? price : 0;
+        fallback.quantity = quantity;
+      }
+    });
+  }
+  renderOptaelling();
+}
+
+function applyLaborSnapshot(labor = []) {
+  if (Array.isArray(labor)) {
+    laborEntries = labor.map(entry => ({ ...entry }));
+  } else {
+    laborEntries = [];
+  }
+  populateWorkersFromLabor(laborEntries);
+}
+
+function applyProjectSnapshot(snapshot, options = {}) {
+  if (!snapshot || typeof snapshot !== 'object') return;
+  const info = snapshot.sagsinfo || {};
+  setSagsinfoField('sagsnummer', info.sagsnummer || '');
+  setSagsinfoField('sagsnavn', info.navn || '');
+  setSagsinfoField('sagsadresse', info.adresse || '');
+  setSagsinfoField('sagskunde', info.kunde || '');
+  setSagsinfoField('sagsdato', info.dato || '');
+  setSagsinfoField('sagsmontoer', info.montoer || '');
+
+  if (info.status || snapshot.status) {
+    currentStatus = (info.status || snapshot.status || 'kladde').toLowerCase();
+    syncStatusUI(currentStatus);
+  } else {
+    syncStatusUI(currentStatus);
+  }
+
+  applyMaterialsSnapshot(snapshot.materials, snapshot.systems);
+  applyExtrasSnapshot(snapshot.extras);
+  applyLaborSnapshot(snapshot.labor);
+
+  if (snapshot.totals) {
+    if (Number.isFinite(snapshot.totals.materialSum)) {
+      lastMaterialSum = snapshot.totals.materialSum;
+    }
+    if (Number.isFinite(snapshot.totals.laborSum)) {
+      lastLoensum = snapshot.totals.laborSum;
+    }
+  }
+
+  updateTotals(true);
+  validateSagsinfo();
+  if (!options?.skipHint) {
+    updateActionHint('Sag er indlæst.', 'success');
+  }
+}
+
+async function handleLoadCase() {
+  const select = document.getElementById('recentCases');
+  if (!select) return;
+  const value = Number(select.value);
+  if (!Number.isFinite(value) || value <= 0) return;
+  let record = recentCasesCache.find(entry => Number(entry.id) === value);
+  if (!record) {
+    const cases = await getRecentProjects();
+    recentCasesCache = cases;
+    record = cases.find(entry => Number(entry.id) === value);
+  }
+  if (record && record.data) {
+    applyProjectSnapshot(record.data, { skipHint: false });
+  } else {
+    updateActionHint('Kunne ikke indlæse den valgte sag.', 'error');
+  }
+}
+
 function validateSagsinfo() {
   let isValid = true;
   sagsinfoFieldIds.forEach(id => {
@@ -1030,7 +1428,7 @@ function validateSagsinfo() {
     el.classList.toggle('invalid', !fieldValid);
   });
 
-  ['btnExportCSV', 'btnExportAll', 'btnPrint'].forEach(id => {
+  ['btnExportCSV', 'btnExportAll', 'btnExportZip', 'btnPrint'].forEach(id => {
     const btn = document.getElementById(id);
     if (btn) btn.disabled = !isValid;
   });
@@ -1363,7 +1761,7 @@ function setupCSVImport() {
     dropArea.classList.remove('dragover');
     const file = event.dataTransfer?.files?.[0];
     if (file) {
-      uploadCSV(file);
+      handleImportFile(file);
       fileInput.value = '';
     }
   });
@@ -1379,10 +1777,20 @@ function setupCSVImport() {
   fileInput.addEventListener('change', event => {
     const file = event.target.files?.[0];
     if (file) {
-      uploadCSV(file);
+      handleImportFile(file);
       fileInput.value = '';
     }
   });
+}
+
+function handleImportFile(file) {
+  if (!file) return;
+  const fileName = file.name || '';
+  if (/\.json$/i.test(fileName) || (file.type && file.type.includes('json'))) {
+    importJSONProject(file);
+    return;
+  }
+  uploadCSV(file);
 }
 
 // --- Authentication ---
@@ -1479,9 +1887,6 @@ function beregnLon() {
   const grundloen = 147;
   const tillægUdd1 = 42.98;
   const tillægUdd2 = 49.38;
-  const TRAELLE_RATE35 = 10.44;
-  const TRAELLE_RATE50 = 14.62;
-
   lastEkompletData = null;
 
   const antalBoringHuller = parseFloat(document.getElementById('antalBoringHuller')?.value) || 0;
@@ -1495,10 +1900,21 @@ function beregnLon() {
   const boringHullerTotal = antalBoringHuller * boringHullerPris;
   const lukHullerTotal = antalLukHuller * lukHullerPris;
   const boringBetonTotal = antalBoringBeton * boringBetonPris;
-  const ekstraarbejde = boringHullerTotal + lukHullerTotal + boringBetonTotal;
   const kilometerPris = antalKm * kmPris;
   const slaebebelob = montagepris * slaebePct; // Slæb beregnes altid ud fra montagepris
-  const traelleSum = (traelle35 * TRAELLE_RATE35) + (traelle50 * TRAELLE_RATE50);
+  const traelle35Total = traelle35 * TRAELLE_RATE35;
+  const traelle50Total = traelle50 * TRAELLE_RATE50;
+  const traelleSum = traelle35Total + traelle50Total;
+
+  if (typeof window !== 'undefined') {
+    window.__traelleloeft = {
+      n35: traelle35,
+      n50: traelle50,
+      RATE35: TRAELLE_RATE35,
+      RATE50: TRAELLE_RATE50,
+      sum: traelleSum,
+    };
+  }
 
   let materialeTotal = 0;
   const materialLines = [];
@@ -1532,6 +1948,7 @@ function beregnLon() {
     });
   }
 
+  const ekstraarbejde = boringHullerTotal + lukHullerTotal + boringBetonTotal + traelleSum;
   const samletAkkordSum = materialeTotal + ekstraarbejde + kilometerPris + slaebebelob;
 
   const workers = document.querySelectorAll('.worker-row');
@@ -1611,7 +2028,7 @@ function beregnLon() {
   });
 
   const resultatDiv = document.getElementById('lonResult');
-  const materialSum = calcMaterialesum();
+  const materialSum = calcMaterialesum() + traelleSum;
   const projektsum = materialSum + samletUdbetalt;
   const datoDisplay = formatDateForDisplay(info.dato);
   if (resultatDiv) {
@@ -1627,6 +2044,7 @@ function beregnLon() {
       { label: 'Navn', value: info.navn || '' },
       { label: 'Adresse', value: info.adresse || '' },
       { label: 'Dato', value: datoDisplay },
+      { label: 'Status', value: formatStatusLabel(info.status) },
     ];
 
     fields.forEach(({ label, value }) => {
@@ -1683,6 +2101,7 @@ function beregnLon() {
       ['Materialer (akkordberegnet)', `${materialeTotal.toFixed(2)} kr`],
       ['Materialesum', `${materialSum.toFixed(2)} kr`],
       ['Ekstraarbejde', `${ekstraarbejde.toFixed(2)} kr`],
+      ['Tralleløft', `${traelleSum.toFixed(2)} kr`],
       ['Kilometer', `${kilometerPris.toFixed(2)} kr`],
       ['Samlet akkordsum', `${samletAkkordSum.toFixed(2)} kr`],
       ['Timer', `${samletTimer.toFixed(1)} t`],
@@ -1735,6 +2154,15 @@ function beregnLon() {
       lukHuller: { antal: antalLukHuller, pris: lukHullerPris, total: lukHullerTotal },
       boringBeton: { antal: antalBoringBeton, pris: boringBetonPris, total: boringBetonTotal },
       kilometer: { antal: antalKm, pris: kmPris, total: kilometerPris },
+      traelleloeft: {
+        antal35: traelle35,
+        pris35: TRAELLE_RATE35,
+        total35: traelle35Total,
+        antal50: traelle50,
+        pris50: TRAELLE_RATE50,
+        total50: traelle50Total,
+        total: traelleSum,
+      },
     },
     materialer: materialerTilEkomplet,
     arbejdere: beregnedeArbejdere,
@@ -1772,6 +2200,8 @@ function beregnLon() {
       timestamp: Date.now(),
     };
   }
+
+  persistProjectSnapshot();
 
   return sagsnummer;
 }
@@ -1938,10 +2368,10 @@ function downloadEkompletCSV() {
 
 
 // --- CSV-eksport ---
-function downloadCSV(customSagsnummer, options = {}) {
+function buildCSVPayload(customSagsnummer, options = {}) {
   if (!options?.skipValidation && !validateSagsinfo()) {
     updateActionHint('Udfyld Sagsinfo for at eksportere.', 'error');
-    return false;
+    return null;
   }
   if (!options?.skipBeregn) {
     beregnLon();
@@ -1952,10 +2382,7 @@ function downloadCSV(customSagsnummer, options = {}) {
   }
   const cache = typeof window !== 'undefined' ? window.__beregnLonCache : null;
   const tralleState = typeof window !== 'undefined' ? window.__traelleloeft : null;
-  const materials = getAllData().filter(item => {
-    const qty = toNumber(item.quantity);
-    return qty > 0;
-  });
+  const materials = getAllData().filter(item => toNumber(item.quantity) > 0);
   const labor = Array.isArray(laborEntries) ? laborEntries : [];
   const tralleSum = tralleState && Number.isFinite(tralleState.sum) ? tralleState.sum : 0;
   const materialSum = cache && Number.isFinite(cache.materialSum)
@@ -1975,7 +2402,8 @@ function downloadCSV(customSagsnummer, options = {}) {
   lines.push(`Sagsinfo;Adresse;${escapeCSV(info.adresse)};;;`);
   lines.push(`Sagsinfo;Kunde;${escapeCSV(info.kunde)};;;`);
   lines.push(`Sagsinfo;Dato;${escapeCSV(info.dato)};;;`);
-  const montorText = info.montoer.replace(/\r?\n/g, ', ');
+  lines.push(`Sagsinfo;Status;${escapeCSV(formatStatusLabel(info.status))};;;`);
+  const montorText = (info.montoer || '').replace(/\r?\n/g, ', ');
   lines.push(`Sagsinfo;Montørnavne;${escapeCSV(montorText)};;;`);
 
   lines.push('');
@@ -2026,14 +2454,24 @@ function downloadCSV(customSagsnummer, options = {}) {
   lines.push(`Total;Lønsum;${escapeCSV(formatNumberForCSV(laborSum))}`);
   lines.push(`Total;Projektsum;${escapeCSV(formatNumberForCSV(projectSum))}`);
 
-  const csvContent = lines.join('\n');
-  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-  const url = URL.createObjectURL(blob);
-  const fileName = sanitizeFilename(info.sagsnummer || 'akkordseddel');
+  const content = lines.join('\n');
+  const baseName = sanitizeFilename(info.sagsnummer || 'akkordseddel') || 'akkordseddel';
+  return {
+    content,
+    baseName,
+    fileName: `${baseName}.csv`,
+    originalName: info.sagsnummer,
+  };
+}
 
+function downloadCSV(customSagsnummer, options = {}) {
+  const payload = buildCSVPayload(customSagsnummer, options);
+  if (!payload) return false;
+  const blob = new Blob([payload.content], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
   link.href = url;
-  link.download = `${fileName}.csv`;
+  link.download = payload.fileName;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
@@ -2042,11 +2480,16 @@ function downloadCSV(customSagsnummer, options = {}) {
   return true;
 }
 
+function generateCSVString(options = {}) {
+  const payload = buildCSVPayload(options?.customSagsnummer, options);
+  return payload ? payload.content : '';
+}
+
 // --- PDF-eksport (html2canvas + jsPDF) ---
-async function exportPDF(customSagsnummer, options = {}) {
-  if (!validateSagsinfo()) {
+async function exportPDFBlob(customSagsnummer, options = {}) {
+  if (!options?.skipValidation && !validateSagsinfo()) {
     updateActionHint('Udfyld Sagsinfo for at eksportere.', 'error');
-    return;
+    return null;
   }
   if (!options?.skipBeregn) {
     beregnLon();
@@ -2057,10 +2500,7 @@ async function exportPDF(customSagsnummer, options = {}) {
   }
   const cache = typeof window !== 'undefined' ? window.__beregnLonCache : null;
   const tralleState = typeof window !== 'undefined' ? window.__traelleloeft : null;
-  const materials = getAllData().filter(item => {
-    const qty = toNumber(item.quantity);
-    return qty > 0;
-  });
+  const materials = getAllData().filter(item => toNumber(item.quantity) > 0);
   const labor = Array.isArray(laborEntries) ? laborEntries : [];
   const tralleSum = tralleState && Number.isFinite(tralleState.sum) ? tralleState.sum : 0;
   const materialSum = cache && Number.isFinite(cache.materialSum)
@@ -2105,6 +2545,7 @@ async function exportPDF(customSagsnummer, options = {}) {
         <li><strong>Adresse:</strong> ${escapeHtml(info.adresse)}</li>
         <li><strong>Kunde:</strong> ${escapeHtml(info.kunde)}</li>
         <li><strong>Dato:</strong> ${escapeHtml(info.dato)}</li>
+        <li><strong>Status:</strong> ${escapeHtml(formatStatusLabel(info.status))}</li>
         <li><strong>Montørnavne:</strong> ${escapeHtml(info.montoer).replace(/\n/g, '<br>')}</li>
       </ul>
     </section>
@@ -2167,14 +2608,66 @@ async function exportPDF(customSagsnummer, options = {}) {
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF({ unit: 'px', format: [canvas.width, canvas.height] });
     doc.addImage(canvas.toDataURL('image/png'), 'PNG', 0, 0, canvas.width, canvas.height);
-    const fileName = sanitizeFilename(info.sagsnummer || 'akkordseddel');
-    doc.save(`${fileName}.pdf`);
-    updateActionHint('PDF er gemt til din enhed.', 'success');
+    const baseName = sanitizeFilename(info.sagsnummer || 'akkordseddel');
+    const blob = doc.output('blob');
+    return { blob, baseName, fileName: `${baseName}.pdf` };
   } catch (err) {
     console.error('PDF eksport fejlede:', err);
     updateActionHint('PDF eksport fejlede. Prøv igen.', 'error');
+    return null;
   } finally {
     document.body.removeChild(wrapper);
+  }
+}
+
+async function exportPDF(customSagsnummer, options = {}) {
+  const payload = await exportPDFBlob(customSagsnummer, options);
+  if (!payload) return;
+  const url = URL.createObjectURL(payload.blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = payload.fileName;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+  updateActionHint('PDF er gemt til din enhed.', 'success');
+}
+
+async function exportZip() {
+  if (!validateSagsinfo()) {
+    updateActionHint('Udfyld Sagsinfo for at eksportere.', 'error');
+    return;
+  }
+  if (typeof JSZip === 'undefined') {
+    updateActionHint('ZIP bibliotek er ikke indlæst.', 'error');
+    return;
+  }
+  try {
+    beregnLon();
+    const csvPayload = buildCSVPayload(null, { skipValidation: true, skipBeregn: true });
+    if (!csvPayload) return;
+    const pdfPayload = await exportPDFBlob(csvPayload.originalName || csvPayload.baseName, { skipValidation: true, skipBeregn: true });
+    if (!pdfPayload) return;
+
+    const zip = new JSZip();
+    zip.file(csvPayload.fileName, csvPayload.content);
+    zip.file(pdfPayload.fileName, pdfPayload.blob);
+
+    const zipBlob = await zip.generateAsync({ type: 'blob' });
+    const url = URL.createObjectURL(zipBlob);
+    const link = document.createElement('a');
+    const baseName = csvPayload.baseName || pdfPayload.baseName || 'akkordseddel';
+    link.href = url;
+    link.download = `${baseName}.zip`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+    updateActionHint('ZIP med PDF og CSV er gemt.', 'success');
+  } catch (error) {
+    console.error('ZIP eksport fejlede', error);
+    updateActionHint('ZIP eksport fejlede. Prøv igen.', 'error');
   }
 }
 
@@ -2192,6 +2685,29 @@ async function exportAll(customSagsnummer) {
 }
 
 // --- CSV-import for optælling ---
+function importJSONProject(file) {
+  const reader = new FileReader();
+  reader.onload = event => {
+    try {
+      const text = event.target?.result;
+      const parsed = JSON.parse(text);
+      if (!parsed || typeof parsed !== 'object') {
+        throw new Error('Ugyldigt JSON format');
+      }
+      const snapshot = parsed.data && !parsed.sagsinfo ? parsed.data : parsed;
+      applyProjectSnapshot(snapshot, { skipHint: true });
+      updateActionHint('JSON sag er indlæst.', 'success');
+    } catch (error) {
+      console.error('Kunne ikke importere JSON', error);
+      updateActionHint('Kunne ikke importere JSON-filen.', 'error');
+    }
+  };
+  reader.onerror = () => {
+    updateActionHint('Kunne ikke læse filen.', 'error');
+  };
+  reader.readAsText(file, 'utf-8');
+}
+
 function uploadCSV(file) {
   if (!file) return;
   if (!/\.csv$/i.test(file.name) && !(file.type && file.type.includes('csv'))) {
@@ -2493,7 +3009,6 @@ function initApp() {
     { id: 'btnSagsinfo', section: 'sagsinfo' },
     { id: 'btnOptaelling', section: 'optaelling' },
     { id: 'btnLon', section: 'lon' },
-    { id: 'btnGuide', section: 'guide', onActivate: () => openGuideModal() },
   ];
 
   navConfig.forEach(({ id, section, onActivate }) => {
@@ -2501,9 +3016,6 @@ function initApp() {
     if (!button) return;
     button.addEventListener('click', () => {
       vis(section);
-      if (section !== 'guide') {
-        closeGuideModal();
-      }
       if (typeof onActivate === 'function') {
         onActivate();
       }
@@ -2523,6 +3035,9 @@ function initApp() {
 
   setupCSVImport();
 
+  initStatusControls();
+  populateRecentCases();
+
   setupGuideModal();
 
   document.getElementById('btnBeregnLon')?.addEventListener('click', () => beregnLon());
@@ -2540,7 +3055,30 @@ function initApp() {
     await exportAll();
   });
 
+  document.getElementById('btnExportZip')?.addEventListener('click', async () => {
+    await exportZip();
+  });
+
   document.getElementById('btnAddWorker')?.addEventListener('click', () => addWorker());
+
+  const recentSelect = document.getElementById('recentCases');
+  if (recentSelect) {
+    recentSelect.addEventListener('change', event => {
+      const loadBtn = document.getElementById('btnLoadCase');
+      if (loadBtn) {
+        loadBtn.disabled = !(event.target.value);
+      }
+    });
+  }
+  document.getElementById('btnLoadCase')?.addEventListener('click', () => handleLoadCase());
+
+  ['traelleloeft35', 'traelleloeft50'].forEach(id => {
+    const input = document.getElementById(id);
+    if (input) {
+      input.addEventListener('input', () => updateTotals());
+      input.addEventListener('change', () => updateTotals(true));
+    }
+  });
 
   sagsinfoFieldIds.forEach(id => {
     const el = document.getElementById(id);
@@ -2577,145 +3115,3 @@ if (document.readyState === 'loading') {
 } else {
   initApp();
 }
-
-
-// --- Tralleløft patch (0,35 & 0,50) ---
-(function(){
-  const RATE35 = 10.44;
-  const RATE50 = 14.62;
-
-  // Ensure inputs exist (if not, inject a small fieldset under Løn)
-  function ensureFields(){
-    if (!document.getElementById('traelleloeft35')) {
-      const lonSec = document.getElementById('lonSection') || document.querySelector('#lonSection, section[id*=lon]');
-      if (lonSec) {
-        const fs = document.createElement('fieldset');
-        fs.innerHTML = '<legend>Tralleløft</legend><div class="grid-2"><input id="traelleloeft35" placeholder="Tralleløft 0,35 (antal)" inputmode="numeric"><input id="traelleloeft50" placeholder="Tralleløft 0,50 (antal)" inputmode="numeric"></div>';
-        // insert before medarbejdere fieldset if possible
-        const med = lonSec.querySelector('legend, fieldset');
-        lonSec.appendChild(fs);
-      }
-    }
-  }
-
-  function getVals(){
-    const n35 = parseFloat(document.getElementById('traelleloeft35')?.value) || 0;
-    const n50 = parseFloat(document.getElementById('traelleloeft50')?.value) || 0;
-    return { n35, n50, sum: n35*RATE35 + n50*RATE50 };
-  }
-
-  ensureFields();
-
-  // Wrap beregnLon
-  try {
-    const _origBeregn = window.beregnLon || beregnLon;
-    window.beregnLon = function(){
-      const ret = _origBeregn();
-      const el = document.getElementById('lonResult');
-      if (!el) return ret;
-
-      const { n35, n50, sum } = getVals();
-      // store globally for exports
-      window.__traelleloeft = { n35, n50, RATE35, RATE50, sum };
-
-      // Only render section if any quantity > 0
-      if ((n35 + n50) > 0) {
-        const html = `
-          <div class="card">
-            <h4>Tralleløft</h4>
-            <div>0,35 m: ${n35} × ${RATE35.toFixed(2)} kr = ${(n35*RATE35).toFixed(2)} kr</div>
-            <div>0,50 m: ${n50} × ${RATE50.toFixed(2)} kr = ${(n50*RATE50).toFixed(2)} kr</div>
-            <div style="margin-top:6px;font-weight:600;">Tralleløft i alt: ${sum.toFixed(2)} kr</div>
-          </div>`;
-        el.insertAdjacentHTML('beforeend', html);
-      }
-      if (typeof window !== 'undefined') {
-        const cache = window.__beregnLonCache || {};
-        window.__beregnLonCache = {
-          ...cache,
-          traelleSum: sum,
-          timestamp: Date.now(),
-        };
-      }
-      return ret;
-    };
-  } catch(e){ console.warn('Tralleløft: kunne ikke wrappe beregnLon', e); }
-
-})();
-
-
-;(() => {
-  function parseFirstNumberIn(el, label){
-    if (!el) return null;
-    const txt = el.textContent || '';
-    const m = txt.match(/([0-9]+(?:\.[0-9]{3})*(?:\.[0-9]{2})?)/); // naive parse
-    return m ? parseFloat(m[1].replace(/\./g,'.')) : null;
-  }
-
-  function updateTotals(){
-    const lr = document.getElementById('lonResult');
-    if (!lr) return;
-    const { sum } = window.__traelleloeft || { sum:0 };
-
-    if (sum <= 0) return;
-
-    const divs = Array.from(lr.querySelectorAll('div'));
-    const akkEl = divs.find(d => d.textContent.trim().startsWith('Samlet akkordsum:'));
-    const tprEl = divs.find(d => d.textContent.trim().startsWith('Timepris (uden tillæg):'));
-    const projEl = divs.find(d => d.textContent.trim().startsWith('Samlet projektsum:'));
-
-    // Update akkordsum
-    if (akkEl){
-      const num = (akkEl.textContent.match(/([0-9]+(?:\.[0-9]{2}))/) || [,'0'])[1];
-      const oldVal = parseFloat(num);
-      if (!isNaN(oldVal)){
-        const newVal = oldVal + sum;
-        akkEl.innerHTML = `<strong>Samlet akkordsum:</strong> ${newVal.toFixed(2)} kr`;
-      }
-    }
-
-    // Update timepris (uden tillæg) using samletTimer from text
-    // Extract 'Timer:' line
-    const timerEl = divs.find(d => d.textContent.trim().startsWith('Timer:'));
-    if (tprEl && timerEl){
-      const numTimer = (timerEl.textContent.match(/([0-9]+(?:\.[0-9])?)/) || [,'0'])[1];
-      const hours = parseFloat(numTimer);
-      const akkEl2 = divs.find(d => d.textContent.trim().startsWith('Samlet akkordsum:'));
-      if (!isNaN(hours) && hours>0 && akkEl2){
-        const numAkk = (akkEl2.textContent.match(/([0-9]+(?:\.[0-9]{2}))/) || [,'0'])[1];
-        const akk = parseFloat(numAkk);
-        tprEl.innerHTML = `<strong>Timepris (uden tillæg):</strong> ${(akk / hours).toFixed(2)} kr/t`;
-      }
-    }
-
-    // Update projektsum by adding tralleløft sum (approx)
-    if (projEl){
-      const num = (projEl.textContent.match(/([0-9]+(?:\.[0-9]{2}))/) || [,'0'])[1];
-      const oldVal = parseFloat(num);
-      if (!isNaN(oldVal)){
-        const newVal = oldVal + sum;
-        projEl.innerHTML = `<strong>Samlet projektsum:</strong> ${newVal.toFixed(2)} kr`;
-      }
-    }
-
-    if (typeof window !== 'undefined') {
-      const baseMaterial = typeof lastMaterialSum === 'number' ? lastMaterialSum : 0;
-      const baseLabor = typeof lastLoensum === 'number' ? lastLoensum : 0;
-      window.__beregnLonCache = {
-        materialSum: baseMaterial + sum,
-        laborSum: baseLabor,
-        projectSum: baseMaterial + sum + baseLabor,
-        traelleSum: sum,
-        timestamp: Date.now(),
-      };
-    }
-  }
-
-  // Hook into beregnLon again to run adjustments after insertion
-  const _b = window.beregnLon;
-  window.beregnLon = function(){
-    const r = _b.apply(this, arguments);
-    try { updateTotals(); } catch(e){ console.warn('Tralleløft totals adjust failed', e); }
-    return r;
-  };
-})();

--- a/main.js
+++ b/main.js
@@ -22,20 +22,38 @@ function forEachNode(nodeList, callback) {
 
 function vis(id) {
   const targetId = resolveSectionId(id);
+  const sections = document.querySelectorAll('.sektion');
 
-  forEachNode(document.querySelectorAll('.sektion'), section => {
-    const isActive = section.id === targetId;
-    section.toggleAttribute('hidden', !isActive);
-    if (isActive) {
-      section.style.removeProperty('display');
-    } else {
-      section.style.display = 'none';
+  if (!sections.length) return;
+
+  let activeId = targetId;
+  let hasMatch = false;
+  for (let index = 0; index < sections.length; index += 1) {
+    if (sections[index].id === activeId) {
+      hasMatch = true;
+      break;
     }
+  }
+
+  if (!hasMatch) {
+    const fallback = sections[0];
+    activeId = fallback ? fallback.id : '';
+  }
+
+  forEachNode(sections, section => {
+    const isActive = section.id === activeId;
+    section.classList.toggle('active', isActive);
+    section.style.display = isActive ? 'flex' : 'none';
+    section.toggleAttribute('hidden', !isActive);
+    section.setAttribute('aria-hidden', isActive ? 'false' : 'true');
   });
 
-  forEachNode(document.querySelectorAll('header nav button[data-section]'), btn => {
+  const navButtons = document.querySelectorAll('header nav button[data-section]');
+  forEachNode(navButtons, btn => {
     const buttonTarget = resolveSectionId(btn.dataset.section);
-    btn.classList.toggle('active', buttonTarget === targetId);
+    const isActive = buttonTarget === activeId;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
 }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,1 +1,56 @@
-const C='scafix-v6';self.addEventListener('install',e=>{self.skipWaiting();e.waitUntil(caches.open(C).then(c=>c.addAll(['./index.html','./style.css','./print.css','./main.js','./complete_lists.json','./dataset.js']))) });self.addEventListener('activate',e=>{e.waitUntil(caches.keys().then(k=>Promise.all(k.map(x=>x!==C&&caches.delete(x))))).then(()=>self.clients.claim())});self.addEventListener('fetch',e=>{e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request).catch(()=>caches.match('./index.html'))))});
+const CACHE_NAME = 'csmate-v1.3';
+const ASSETS = [
+  './',
+  './index.html',
+  './style.css',
+  './print.css',
+  './main.js',
+  './dataset.js',
+  './complete_lists.json',
+  './manifest.json',
+  './placeholder_light_gray_block.png',
+];
+
+self.addEventListener('install', event => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS)),
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then(keys => keys.filter(key => key !== CACHE_NAME))
+      .then(oldKeys => Promise.all(oldKeys.map(key => caches.delete(key))))
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  const requestUrl = new URL(event.request.url);
+  if (requestUrl.origin !== self.location.origin) {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(cached => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(event.request);
+    }).catch(() => {
+      if (event.request.mode === 'navigate') {
+        return caches.match('./index.html');
+      }
+
+      return Response.error();
+    }),
+  );
+});

--- a/style.css
+++ b/style.css
@@ -30,6 +30,7 @@ input,select,textarea,button{background:var(--panel);color:var(--text);border:1p
 textarea{resize:vertical}
 button{cursor:pointer}
 .sektion{display:flex;flex-direction:column;gap:var(--gap)}
+.sektion.active{display:flex!important;}
 .row{display:flex;gap:8px;flex-wrap:wrap}
 .btn-group{display:flex;gap:8px;flex-wrap:wrap}
 .grid-3{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--gap)}

--- a/style.css
+++ b/style.css
@@ -22,6 +22,16 @@ fieldset{border:1px solid var(--border);background:var(--panel);border-radius:12
 legend{color:var(--muted);padding:0 6px}
 label{display:flex;flex-direction:column;gap:6px;font-size:0.95rem}
 label span{color:var(--muted);font-size:0.85rem}
+.status-bar{display:flex;gap:16px;flex-wrap:wrap;align-items:flex-end;margin-bottom:var(--gap)}
+.status-select{min-width:220px}
+.status-indicator{display:flex;flex-direction:column;gap:6px;min-width:180px}
+.status-indicator span{color:var(--muted);font-size:0.85rem}
+.status-pill{display:inline-flex;align-items:center;justify-content:center;padding:8px 14px;border-radius:999px;border:1px solid var(--border);background:rgba(255,255,255,0.05);text-transform:capitalize;font-weight:600;min-width:140px;text-align:center}
+.status-pill[data-status="afventer"]{background:rgba(255,196,38,0.12);color:#ffd66c;border-color:rgba(255,196,38,0.4)}
+.status-pill[data-status="godkendt"]{background:rgba(93,201,133,0.18);color:#8adbae;border-color:rgba(93,201,133,0.4)}
+.status-pill[data-status="afvist"]{background:rgba(214,102,102,0.18);color:#ff9b9b;border-color:rgba(214,102,102,0.4)}
+.form-actions{margin-top:var(--gap);display:flex;justify-content:flex-end}
+.form-actions button{min-width:160px}
 .date-field .date-input-wrapper{display:flex;align-items:center;gap:8px}
 .date-field .date-input-wrapper input[type=date]{flex:1}
 .date-picker-trigger{display:inline-flex;align-items:center;justify-content:center;min-height:44px;min-width:44px;padding:0 12px;font-size:1.25rem;line-height:1;border:1px solid var(--border);background:var(--elev)}
@@ -59,16 +69,18 @@ button{cursor:pointer}
 .import-zone{background:var(--panel);border:1px dashed var(--border);border-radius:12px;padding:var(--pad)}
 .drop-area{border:2px dashed #aaa;border-radius:8px;padding:24px;text-align:center;display:flex;flex-direction:column;gap:6px;justify-content:center;align-items:center;min-height:140px;transition:all .2s ease}
 .drop-area.dragover{border-color:#333;background:rgba(255,255,255,0.05)}
+.recent-cases{margin-top:var(--gap);display:flex;gap:8px;flex-wrap:wrap}
+.recent-cases select{flex:1 1 200px;min-width:200px}
+.recent-cases button{flex:0 0 auto;min-width:140px}
 .hint{font-size:0.9rem;color:var(--muted);margin:0}
 .hint.error{color:#ff9b9b}
 .hint.success{color:#8adbae}
 .invalid{border-color:#d66;background:rgba(214,102,102,0.15)}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
-.guide-intro{display:flex;flex-direction:column;gap:12px;background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:var(--pad)}
-.guide-intro h2{margin:0;font-size:1.4rem}
-.guide-intro p{margin:0;color:var(--muted);line-height:1.5}
-.guide-intro button{align-self:flex-start}
+.overview-inline{background:transparent;border:none;padding:0}
+.overview-inline .totals div{background:var(--elev)}
 .worker-row{display:flex;flex-direction:column;gap:12px}
+.extra-work-grid{grid-template-columns:repeat(auto-fit,minmax(180px,1fr))}
 .worker-grid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:var(--gap)}
 .worker-grid label{display:flex;flex-direction:column;gap:6px}
 .worker-grid span{color:var(--muted);font-size:0.85rem}
@@ -118,6 +130,10 @@ button{cursor:pointer}
   .grid-2{grid-template-columns:1fr}
   .worker-grid{grid-template-columns:1fr}
   .totals{grid-template-columns:1fr}
+  .recent-cases{flex-direction:column}
+  .recent-cases button{width:100%}
+  .status-bar{flex-direction:column;align-items:flex-start}
+  .status-pill{min-width:0;width:100%;justify-content:flex-start;padding-inline:12px}
   .material-row{grid-template-columns:1fr;grid-auto-rows:auto}
   .material-row .item-total{grid-column:1/-1}
   .btn-group{flex-direction:column}


### PR DESCRIPTION
## Summary
- ensure the tab switcher gracefully falls back when ids are missing while updating aria attributes for buttons and panels
- keep inactive sections hidden with consistent display handling so the layout remains intact on mobile
- scope the service worker fetch handler to same-origin GET requests, fall back for navigations only, and bump the cache version

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4954cb680832a82fe4412c6e59fa5